### PR TITLE
template-left-col.php: Move sidebar to the left

### DIFF
--- a/page-templates/template-left-col.php
+++ b/page-templates/template-left-col.php
@@ -13,6 +13,8 @@
 
 get_header(); ?>
 
+	<?php get_sidebar(); ?>
+
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">
 
@@ -42,5 +44,4 @@ get_header(); ?>
 		</main><!-- #main -->
 	</div><!-- #primary -->
 
-<?php get_sidebar(); ?>
 <?php get_footer(); ?>


### PR DESCRIPTION
Seeing as the template is for a left column page, we should probably have the sidebar on the left...
This is a quick fix, but it works for now. Get off my back.
