### PR TITLE
Jb510 patch 1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,8 +5,8 @@
 */
 
 // Project configuration
-var 	project 	= 'somelikeitneat', // Optional - Use your own project name here, used for build zip.
-	url 		= 'somelikeitneat.dev', // Used for browser sync
+var 	project 	= 'somelikeitneat', // Project name, used for build zip.
+	url 		= 'somelikeitneat.dev', // Local Development URL for BrowserSync
 	build 		= './build/', // Files that you want to package into a zip go here
 	source 		= './assets/', 	// Your main project assets and naming 'source' instead of 'src' to avoid confusion with gulp.src
 	bower 		= './assets/bower_components/', // Not truly using this yet, more or less playing right now. TO-DO Place in Dev branch

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,8 @@
 */
 
 // Project configuration
-var project 	= 'somelikeitneat', // Optional - Use your own project name here...
+var 	project 	= 'somelikeitneat', // Optional - Use your own project name here, used for build zip.
+	url 		= 'somelikeitneat.dev', // Used for browser sync
 	build 		= './build/', // Files that you want to package into a zip go here
 	source 		= './assets/', 	// Your main project assets and naming 'source' instead of 'src' to avoid confusion with gulp.src
 	bower 		= './assets/bower_components/', // Not truly using this yet, more or less playing right now. TO-DO Place in Dev branch
@@ -49,7 +50,7 @@ gulp.task('browser-sync', function() {
 		'**/*.php'
 	];
 	browserSync.init(files, {
-		proxy: project+".dev"
+		proxy: url
 	});
 });
 


### PR DESCRIPTION
Splits project var into project and url. 

URL is used for browser sync and will vary depending on local hosting setup.

PROJECT is still used for build zip and elsewhere.

Note, your last commit left the + on project.  ie. project+ (nevermind, the stray plus was fixed in 5fdf798dbf169bb1f5368db0d28d476f82c7a198 ) 

fixes and closed #64
