### PR TITLE
Ran into issue with current GitHub version not enqueuing stylesheets 

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -192,7 +192,7 @@ if ( ! function_exists( 'some_like_it_neat_scripts' ) ) :
 		}
 	}
 	add_action( 'wp_enqueue_scripts', 'some_like_it_neat_scripts' );
-endif; // Enqueue scripts
+endif; // Enqueue scripts and styles
 
 /**
  * Register widgetized area and update sidebar with default widgets.

--- a/functions.php
+++ b/functions.php
@@ -189,20 +189,6 @@ if ( ! function_exists( 'some_like_it_neat_scripts' ) ) :
 endif; // Enqueue scripts
 
 /**
- * Enqueue styles.
- */
-if ( ! function_exists( 'some_like_it_neat_styles' ) ) :
-	function some_like_it_neat_styles() {
-		if ( SCRIPT_DEBUG || WP_DEBUG ) :
-			wp_enqueue_style( 'some_like_it_neat-style',  get_template_directory_uri() . '/assets/css/style.css' );
-	  else :
-			wp_enqueue_style( 'some_like_it_neat-style',  get_template_directory_uri() . '/assets/css/style-min.css' );
-    endif;
-	}
-  add_action( 'wp_enqueue_styles', 'some_like_it_neat_styles' );
-endif; // Enqueue styles
-
-/**
  * Register widgetized area and update sidebar with default widgets.
  */
 function some_like_it_neat_widgets_init()

--- a/functions.php
+++ b/functions.php
@@ -136,7 +136,7 @@ endif; // some_like_it_neat_setup
 add_action( 'after_setup_theme', 'some_like_it_neat_setup' );
 
 /**
- * Enqueue scripts.
+ * Enqueue scripts and styles.
  */
 if ( ! function_exists( 'some_like_it_neat_scripts' ) ) :
 	function some_like_it_neat_scripts()

--- a/functions.php
+++ b/functions.php
@@ -178,6 +178,9 @@ if ( ! function_exists( 'some_like_it_neat_scripts' ) ) :
 
 			// Concatonated Scripts
 			// wp_enqueue_script( 'production-js', get_template_directory_uri() . '/assets/js/production-min.js', array( 'jquery' ), '1.0.0', false );
+			
+			// Main Styles
+			wp_enqueue_style( 'some_like_it_neat-style',  get_template_directory_uri() . '/assets/css/style-min.css' );
 
 	 endif;
 

--- a/functions.php
+++ b/functions.php
@@ -160,7 +160,7 @@ if ( ! function_exists( 'some_like_it_neat_scripts' ) ) :
 			// wp_enqueue_script( 'development-js', get_template_directory_uri() . '/assets/js/development.js', array( 'jquery' ), '1.0.0', false );
 			
 			// Main Styles
-			wp_enqueue_style( 'some_like_it_neat-style',  get_template_directory_uri() . '/assets/css/style.css' );
+			wp_enqueue_style( 'some_like_it_neat-style',  get_stylesheet_directory_uri() . '/assets/css/style.css' );
 
 	 else :
 			// Vendor Scripts

--- a/functions.php
+++ b/functions.php
@@ -180,7 +180,7 @@ if ( ! function_exists( 'some_like_it_neat_scripts' ) ) :
 			// wp_enqueue_script( 'production-js', get_template_directory_uri() . '/assets/js/production-min.js', array( 'jquery' ), '1.0.0', false );
 			
 			// Main Styles
-			wp_enqueue_style( 'some_like_it_neat-style',  get_template_directory_uri() . '/assets/css/style-min.css' );
+			wp_enqueue_style( 'some_like_it_neat-style',  get_stylesheet_directory_uri() . '/assets/css/style-min.css' );
 
 	 endif;
 

--- a/functions.php
+++ b/functions.php
@@ -158,6 +158,9 @@ if ( ! function_exists( 'some_like_it_neat_scripts' ) ) :
 
 			// Concatonated Scripts
 			// wp_enqueue_script( 'development-js', get_template_directory_uri() . '/assets/js/development.js', array( 'jquery' ), '1.0.0', false );
+			
+			// Main Styles
+			wp_enqueue_style( 'some_like_it_neat-style',  get_template_directory_uri() . '/assets/css/style.css' );
 
 	 else :
 			// Vendor Scripts


### PR DESCRIPTION
I really like this starter theme. However, the current GitHub version (1.3.1) is not enqueuing stylesheets. Using the WordPress.org version (1.1.10), stylesheets do enqueue. In 1.1.10's functions.php file, scripts and styles are enqueued together. I tweaked my local copy of 1.3.1 so that scripts and styles enqueue in the same function and it fixed the issue. Submitting these changes for your consideration.

Awesome theme. Thank you for making this. I'd like to do what I can to contribute to this project.