### PR TITLE
Better Legacy Support

### DIFF
--- a/header.php
+++ b/header.php
@@ -16,6 +16,7 @@
     <?php tha_head_top(); ?>
 
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="profile" href="http://gmpg.org/xfn/11">
 	<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">


### PR DESCRIPTION
Since were using selectivizr and modernizr, makes sense to add the x-ua-compatible tag to better support legacy browsers. An alternative and probably even a better way to do this to avoid issues with too many characters coming before the x-ua-compatible tag is to use http headers:

```php
add_action( 'send_headers', 'some_like_it_neat_legacy_browsers' );
function some_like_it_neat_legacy_browsers() {
	header( 'X-UA-Compatible: IE=edge,chrome=1' );
}
```